### PR TITLE
Added a check for the filename in Apples response headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,6 +112,8 @@ AutoIngestion.prototype._download = function(requestParams, downloadPath, callba
     if (response.statusCode == 200) {
       if (response.headers.errormsg !== undefined && response.headers.errormsg !== null) {
         callback(new Error(response.headers.errormsg));
+      } else if(typeof response.headers.filename == 'undefined') {
+        callback(new Error('No report available.'));
       } else {
         downloadFilePath = path.join(downloadPath, response.headers.filename);
 


### PR DESCRIPTION
Sometimes Apple's API responds with no content, no filename in the header, nothing useful. Node's path.join() complains if you don't give it string arguments, and since there's no actual file content to write to disk, we should jail be bailing with an informative error message when this occurs.